### PR TITLE
Update "expect_no_error" to report raised exceptions

### DIFF
--- a/codewars_test/test_framework.py
+++ b/codewars_test/test_framework.py
@@ -57,14 +57,14 @@ def expect_error(message, function, exception=Exception):
 
 
 def expect_no_error(message, function, exception=BaseException):
-    passed = True
     try:
         function()
-    except exception:
-        passed = False
+    except exception as e:
+        fail("{}: {}".format(message or "Unexpected exception", repr(e)))
+        return
     except Exception:
         pass
-    expect(passed, message)
+    pass_()
 
 
 def pass_(): expect(True)
@@ -137,7 +137,7 @@ Note: Timeout value can be a float.
 def timeout(sec):
     def wrapper(func):
         from multiprocessing import Process
-        msg = 'Should not throw any exception inside timeout'
+        msg = 'Should not throw any exceptions inside timeout'
 
         def wrapped():
             expect_no_error(msg, func)


### PR DESCRIPTION
As `expect_no_error` silently consumes any exceptions raised in the code, the user may have no information about what's happening or why some particular test failed. Normally, authors have to specify a custom error message to avoid this, but this is not the case with the `timeout` decorator: it delegates execution to `expect_no_error` while catching all exceptions with a useless `"Should not throw any exception inside timeout"` error message. This quick fix should make timed blocks more informative on failure, and provide some minimal info if an empty string is passed as the `message` argument.