### PR TITLE
handle and display AssertionErrors

### DIFF
--- a/codewars_test/test_framework.py
+++ b/codewars_test/test_framework.py
@@ -109,6 +109,8 @@ def _timed_block_factory(opening_text):
             time = timer()
             try:
                 func()
+            except AssertionError as e:
+                display('FAILED', str(e))
             except Exception:
                 fail('Unexpected exception raised')
                 tb_str = ''.join(format_exception(*exc_info()))


### PR DESCRIPTION
This allows frameworks like numpy to raise `AssertionError`s which can be handled in a similar way to in-suite assertion errors.

```python
import numpy as np
import test_framework as test

@test.describe('Example Tests')
def example_tests():
    @test.it('Example Test Case')
    def example_test_case():
        actual = np.reshape(range(16), [4, 4])
        expected = np.reshape(range(1, 17), [4, 4])
        np.testing.assert_equal(expected, actual)
```

which produces:

```
<DESCRIBE::>Example Tests

<IT::>Example Test Case

<FAILED::><:LF:>Arrays are not equal<:LF:><:LF:>Mismatched elements: 16 / 16 (100%)<:LF:>Max absolute difference: 1<:LF:>Max relative difference: 1.<:LF:> x: array([[ 1,  2,  3,  4],<:LF:>       [ 5,  6,  7,  8],<:LF:>       [ 9, 10, 11, 12],<:LF:>       [13, 14, 15, 16]])<:LF:> y: array([[ 0,  1,  2,  3],<:LF:>       [ 4,  5,  6,  7],<:LF:>       [ 8,  9, 10, 11],<:LF:>       [12, 13, 14, 15]])

<COMPLETEDIN::>281.39

<COMPLETEDIN::>287.13
```