### PR TITLE
Use `AssertionError` when inside decorated test case

### DIFF
--- a/codewars_test/test_framework.py
+++ b/codewars_test/test_framework.py
@@ -10,16 +10,19 @@ def format_message(message):
 
 
 def display(type, message, label="", mode=""):
-    print("\n<{0}:{1}:{2}>{3}".format(
-        type.upper(), mode.upper(), label, format_message(message)))
+    print(
+        "\n<{0}:{1}:{2}>{3}".format(
+            type.upper(), mode.upper(), label, format_message(message)
+        )
+    )
 
 
 def expect(passed=None, message=None, allow_raise=False):
     if passed:
-        display('PASSED', 'Test Passed')
+        display("PASSED", "Test Passed")
     else:
         message = message or "Value is not what was expected"
-        display('FAILED', message)
+        display("FAILED", message)
         if allow_raise:
             raise AssertException(message)
 
@@ -67,14 +70,17 @@ def expect_no_error(message, function, exception=BaseException):
     pass_()
 
 
-def pass_(): expect(True)
+def pass_():
+    expect(True)
 
 
-def fail(message): expect(False, message)
+def fail(message):
+    expect(False, message)
 
 
 def assert_approx_equals(
-        actual, expected, margin=1e-9, message=None, allow_raise=False):
+    actual, expected, margin=1e-9, message=None, allow_raise=False
+):
     msg = "{0} should be close to {1} with absolute or relative margin of {2}"
     equals_msg = msg.format(repr(actual), repr(expected), repr(margin))
     if message is None:
@@ -85,14 +91,14 @@ def assert_approx_equals(
     expect(abs((actual - expected) / div) < margin, message, allow_raise)
 
 
-'''
+"""
 Usage:
 @describe('describe text')
 def describe1():
     @it('it text')
     def it1():
         # some test cases...
-'''
+"""
 
 
 def _timed_block_factory(opening_text):
@@ -110,44 +116,49 @@ def _timed_block_factory(opening_text):
             try:
                 func()
             except AssertionError as e:
-                display('FAILED', str(e))
+                display("FAILED", str(e))
             except Exception:
-                fail('Unexpected exception raised')
-                tb_str = ''.join(format_exception(*exc_info()))
-                display('ERROR', tb_str)
-            display('COMPLETEDIN', '{:.2f}'.format((timer() - time) * 1000))
+                fail("Unexpected exception raised")
+                tb_str = "".join(format_exception(*exc_info()))
+                display("ERROR", tb_str)
+            display("COMPLETEDIN", "{:.2f}".format((timer() - time) * 1000))
             if callable(after):
                 after()
+
         return wrapper
+
     return _timed_block_decorator
 
 
-describe = _timed_block_factory('DESCRIBE')
-it = _timed_block_factory('IT')
+describe = _timed_block_factory("DESCRIBE")
+it = _timed_block_factory("IT")
 
 
-'''
+"""
 Timeout utility
 Usage:
 @timeout(sec)
 def some_tests():
     any code block...
 Note: Timeout value can be a float.
-'''
+"""
 
 
 def timeout(sec):
     def wrapper(func):
         from multiprocessing import Process
-        msg = 'Should not throw any exceptions inside timeout'
+
+        msg = "Should not throw any exceptions inside timeout"
 
         def wrapped():
             expect_no_error(msg, func)
+
         process = Process(target=wrapped)
         process.start()
         process.join(sec)
         if process.is_alive():
-            fail('Exceeded time limit of {:.3f} seconds'.format(sec))
+            fail("Exceeded time limit of {:.3f} seconds".format(sec))
             process.terminate()
             process.join()
+
     return wrapper

--- a/tests/fixtures/custom_assertion.expected.txt
+++ b/tests/fixtures/custom_assertion.expected.txt
@@ -1,0 +1,22 @@
+
+<DESCRIBE::>group 1
+
+<IT::>test 1
+
+<PASSED::>Test Passed
+
+<COMPLETEDIN::>0.00
+
+<IT::>test 2
+
+<FAILED::>Expected 1 to equal 2
+
+<COMPLETEDIN::>0.01
+
+<IT::>test 3
+
+<FAILED::>using assert
+
+<COMPLETEDIN::>0.00
+
+<COMPLETEDIN::>0.03

--- a/tests/fixtures/custom_assertion.py
+++ b/tests/fixtures/custom_assertion.py
@@ -1,0 +1,21 @@
+import codewars_test as test
+
+
+def custom_assert_equal(a, b):
+    if a != b:
+        raise AssertionError("Expected {} to equal {}".format(a, b))
+
+
+@test.describe("group 1")
+def group_1():
+    @test.it("test 1")
+    def test_1():
+        custom_assert_equal(1, 1)
+
+    @test.it("test 2")
+    def test_2():
+        custom_assert_equal(1, 2)
+
+    @test.it("test 3")
+    def test_3():
+        assert 1 == 2, "using assert"

--- a/tests/fixtures/expect_error_sample.expected.txt
+++ b/tests/fixtures/expect_error_sample.expected.txt
@@ -5,72 +5,24 @@
 
 <FAILED::>f0 did not raise any exception
 
-<FAILED::>f0 did not raise Exception
-
-<FAILED::>f0 did not raise ArithmeticError
-
-<FAILED::>f0 did not raise ZeroDivisionError
-
-<FAILED::>f0 did not raise LookupError
-
-<FAILED::>f0 did not raise KeyError
-
-<FAILED::>f0 did not raise OSError
-
-<COMPLETEDIN::>0.03
+<COMPLETEDIN::>0.02
 
 <IT::>f1 raises Exception
 
-<PASSED::>Test Passed
-
-<PASSED::>Test Passed
-
 <FAILED::>f1 did not raise ArithmeticError
-
-<FAILED::>f1 did not raise ZeroDivisionError
-
-<FAILED::>f1 did not raise LookupError
-
-<FAILED::>f1 did not raise KeyError
-
-<FAILED::>f1 did not raise OSError
 
 <COMPLETEDIN::>0.02
 
 <IT::>f2 raises Exception >> ArithmeticError >> ZeroDivisionError
 
-<PASSED::>Test Passed
-
-<PASSED::>Test Passed
-
-<PASSED::>Test Passed
-
-<PASSED::>Test Passed
-
 <FAILED::>f2 did not raise LookupError
-
-<FAILED::>f2 did not raise KeyError
-
-<FAILED::>f2 did not raise OSError
 
 <COMPLETEDIN::>0.02
 
 <IT::>f3 raises Exception >> LookupError >> KeyError
 
-<PASSED::>Test Passed
-
-<PASSED::>Test Passed
-
 <FAILED::>f3 did not raise ArithmeticError
-
-<FAILED::>f3 did not raise ZeroDivisionError
-
-<PASSED::>Test Passed
-
-<PASSED::>Test Passed
-
-<FAILED::>f3 did not raise OSError
 
 <COMPLETEDIN::>0.02
 
-<COMPLETEDIN::>0.11
+<COMPLETEDIN::>0.10

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -23,7 +23,12 @@ def test_against_expected(test_file, expected_file, env):
             expected = re.sub(
                 r"(?<=<COMPLETEDIN::>)\d+(?:\.\d+)?", r"\\d+(?:\\.\\d+)?", r.read()
             )
-            self.assertRegex(result.stdout.decode("utf-8"), expected)
+            actual = result.stdout.decode("utf-8")
+            self.assertRegex(
+                actual,
+                expected,
+                "Expected Pattern:\n{}\n\nGot:\n{}\n".format(expected, actual),
+            )
 
     return test
 


### PR DESCRIPTION
- Stops at first failure like most other test frameworks
- Single test passed message regardless of the number of assertions
- Discourage fat test cases
- Allow using external assertions
  - `np.testing.assert_equal`
  - `pd.testing.assert_frame_equal`
  - assertion packages

Tests written in old style are not affected.

Need some review and feedback.

---

Closes #9