### PR TITLE
enhance expect_error feedback

### DIFF
--- a/codewars_test/test_framework.py
+++ b/codewars_test/test_framework.py
@@ -51,8 +51,8 @@ def expect_error(message, function, exception=Exception):
         function()
     except exception:
         passed = True
-    except Exception:
-        pass
+    except Exception as e:
+        message = "{}: {} should be {}".format(message or "Unexpected exception", repr(e), repr(exception))
     expect(passed, message)
 
 
@@ -62,7 +62,7 @@ def expect_no_error(message, function, exception=BaseException):
     except exception as e:
         fail("{}: {}".format(message or "Unexpected exception", repr(e)))
         return
-    except Exception:
+    except:
         pass
     pass_()
 

--- a/tests/fixtures/expect_error_sample.expected.txt
+++ b/tests/fixtures/expect_error_sample.expected.txt
@@ -17,7 +17,7 @@
 
 <FAILED::>f0 did not raise OSError
 
-<COMPLETEDIN::>0.03
+<COMPLETEDIN::>0.3
 
 <IT::>f1 raises Exception
 
@@ -25,15 +25,16 @@
 
 <PASSED::>Test Passed
 
-<FAILED::>f1 did not raise ArithmeticError
+<FAILED::>f1 did not raise ArithmeticError: Exception() should be <class 'ArithmeticError'>
 
-<FAILED::>f1 did not raise ZeroDivisionError
+<FAILED::>f1 did not raise ZeroDivisionError: Exception() should be
+<class 'ZeroDivisionError'>
 
-<FAILED::>f1 did not raise LookupError
+<FAILED::>f1 did not raise LookupError: Exception() should be <class 'LookupError'>
 
-<FAILED::>f1 did not raise KeyError
+<FAILED::>f1 did not raise KeyError: Exception() should be <class 'KeyError'>
 
-<FAILED::>f1 did not raise OSError
+<FAILED::>f1 did not raise OSError: Exception() should be <class 'OSError'>
 
 <COMPLETEDIN::>0.02
 
@@ -47,11 +48,11 @@
 
 <PASSED::>Test Passed
 
-<FAILED::>f2 did not raise LookupError
+<FAILED::>f2 did not raise LookupError: ZeroDivisionError('integer division or modulo by zero',) should be <class 'LookupError'>
 
-<FAILED::>f2 did not raise KeyError
+<FAILED::>f2 did not raise KeyError: ZeroDivisionError('integer division or modulo by zero',) should be <class 'KeyError'>
 
-<FAILED::>f2 did not raise OSError
+<FAILED::>f2 did not raise OSError: ZeroDivisionError('integer division or modulo by zero',) should be <class 'OSError'>
 
 <COMPLETEDIN::>0.02
 
@@ -61,15 +62,15 @@
 
 <PASSED::>Test Passed
 
-<FAILED::>f3 did not raise ArithmeticError
+<FAILED::>f3 did not raise ArithmeticError: KeyError(1,) should be <class 'ArithmeticError'>
 
-<FAILED::>f3 did not raise ZeroDivisionError
-
-<PASSED::>Test Passed
+<FAILED::>f3 did not raise ZeroDivisionError: KeyError(1,) should be <class 'ZeroDivisionError'>
 
 <PASSED::>Test Passed
 
-<FAILED::>f3 did not raise OSError
+<PASSED::>Test Passed
+
+<FAILED::>f3 did not raise OSError: KeyError(1,) should be <class 'OSError'>
 
 <COMPLETEDIN::>0.02
 

--- a/tests/fixtures/expect_error_sample.expected.txt
+++ b/tests/fixtures/expect_error_sample.expected.txt
@@ -17,7 +17,7 @@
 
 <FAILED::>f0 did not raise OSError
 
-<COMPLETEDIN::>0.3
+<COMPLETEDIN::>0.03
 
 <IT::>f1 raises Exception
 


### PR DESCRIPTION
### previously:

when execting a specific error, if any other error is ancountered, the test fails without any useful feedback

### suggestion:

added `{actual error} should be {expected error}` to the message

### note:

this time, I updated the related test output fixture. I checked manually that the behavior was exactly the same.