### PR TITLE
Improve `expect_error` feedback

### DIFF
--- a/codewars_test/test_framework.py
+++ b/codewars_test/test_framework.py
@@ -51,8 +51,8 @@ def expect_error(message, function, exception=Exception):
         function()
     except exception:
         passed = True
-    except Exception:
-        pass
+    except Exception as e:
+        message = "{}: {} should be {}".format(message or "Unexpected exception", repr(e), repr(exception))
     expect(passed, message)
 
 
@@ -62,7 +62,7 @@ def expect_no_error(message, function, exception=BaseException):
     except exception as e:
         fail("{}: {}".format(message or "Unexpected exception", repr(e)))
         return
-    except Exception:
+    except:
         pass
     pass_()
 

--- a/tests/fixtures/expect_error_sample.expected.txt
+++ b/tests/fixtures/expect_error_sample.expected.txt
@@ -17,7 +17,7 @@
 
 <FAILED::>f0 did not raise OSError
 
-<COMPLETEDIN::>0.03
+<COMPLETEDIN::>0.3
 
 <IT::>f1 raises Exception
 
@@ -25,15 +25,16 @@
 
 <PASSED::>Test Passed
 
-<FAILED::>f1 did not raise ArithmeticError
+<FAILED::>f1 did not raise ArithmeticError: Exception() should be <class 'ArithmeticError'>
 
-<FAILED::>f1 did not raise ZeroDivisionError
+<FAILED::>f1 did not raise ZeroDivisionError: Exception() should be
+<class 'ZeroDivisionError'>
 
-<FAILED::>f1 did not raise LookupError
+<FAILED::>f1 did not raise LookupError: Exception() should be <class 'LookupError'>
 
-<FAILED::>f1 did not raise KeyError
+<FAILED::>f1 did not raise KeyError: Exception() should be <class 'KeyError'>
 
-<FAILED::>f1 did not raise OSError
+<FAILED::>f1 did not raise OSError: Exception() should be <class 'OSError'>
 
 <COMPLETEDIN::>0.02
 
@@ -47,11 +48,11 @@
 
 <PASSED::>Test Passed
 
-<FAILED::>f2 did not raise LookupError
+<FAILED::>f2 did not raise LookupError: ZeroDivisionError('integer division or modulo by zero',) should be <class 'LookupError'>
 
-<FAILED::>f2 did not raise KeyError
+<FAILED::>f2 did not raise KeyError: ZeroDivisionError('integer division or modulo by zero',) should be <class 'KeyError'>
 
-<FAILED::>f2 did not raise OSError
+<FAILED::>f2 did not raise OSError: ZeroDivisionError('integer division or modulo by zero',) should be <class 'OSError'>
 
 <COMPLETEDIN::>0.02
 
@@ -61,15 +62,15 @@
 
 <PASSED::>Test Passed
 
-<FAILED::>f3 did not raise ArithmeticError
+<FAILED::>f3 did not raise ArithmeticError: KeyError(1,) should be <class 'ArithmeticError'>
 
-<FAILED::>f3 did not raise ZeroDivisionError
-
-<PASSED::>Test Passed
+<FAILED::>f3 did not raise ZeroDivisionError: KeyError(1,) should be <class 'ZeroDivisionError'>
 
 <PASSED::>Test Passed
 
-<FAILED::>f3 did not raise OSError
+<PASSED::>Test Passed
+
+<FAILED::>f3 did not raise OSError: KeyError(1,) should be <class 'OSError'>
 
 <COMPLETEDIN::>0.02
 

--- a/tests/fixtures/expect_error_sample.expected.txt
+++ b/tests/fixtures/expect_error_sample.expected.txt
@@ -47,11 +47,11 @@
 
 <PASSED::>Test Passed
 
-<FAILED::>f2 did not raise LookupError: ZeroDivisionError('integer division or modulo by zero',) should be <class 'LookupError'>
+<FAILED::>f2 did not raise LookupError: ZeroDivisionError('integer division or modulo by zero') should be <class 'LookupError'>
 
-<FAILED::>f2 did not raise KeyError: ZeroDivisionError('integer division or modulo by zero',) should be <class 'KeyError'>
+<FAILED::>f2 did not raise KeyError: ZeroDivisionError('integer division or modulo by zero') should be <class 'KeyError'>
 
-<FAILED::>f2 did not raise OSError: ZeroDivisionError('integer division or modulo by zero',) should be <class 'OSError'>
+<FAILED::>f2 did not raise OSError: ZeroDivisionError('integer division or modulo by zero') should be <class 'OSError'>
 
 <COMPLETEDIN::>0.02
 
@@ -61,15 +61,15 @@
 
 <PASSED::>Test Passed
 
-<FAILED::>f3 did not raise ArithmeticError: KeyError(1,) should be <class 'ArithmeticError'>
+<FAILED::>f3 did not raise ArithmeticError: KeyError(1) should be <class 'ArithmeticError'>
 
-<FAILED::>f3 did not raise ZeroDivisionError: KeyError(1,) should be <class 'ZeroDivisionError'>
-
-<PASSED::>Test Passed
+<FAILED::>f3 did not raise ZeroDivisionError: KeyError(1) should be <class 'ZeroDivisionError'>
 
 <PASSED::>Test Passed
 
-<FAILED::>f3 did not raise OSError: KeyError(1,) should be <class 'OSError'>
+<PASSED::>Test Passed
+
+<FAILED::>f3 did not raise OSError: KeyError(1) should be <class 'OSError'>
 
 <COMPLETEDIN::>0.02
 

--- a/tests/fixtures/expect_error_sample.expected.txt
+++ b/tests/fixtures/expect_error_sample.expected.txt
@@ -27,8 +27,7 @@
 
 <FAILED::>f1 did not raise ArithmeticError: Exception() should be <class 'ArithmeticError'>
 
-<FAILED::>f1 did not raise ZeroDivisionError: Exception() should be
-<class 'ZeroDivisionError'>
+<FAILED::>f1 did not raise ZeroDivisionError: Exception() should be <class 'ZeroDivisionError'>
 
 <FAILED::>f1 did not raise LookupError: Exception() should be <class 'LookupError'>
 

--- a/tests/fixtures/expect_error_sample.expected.txt
+++ b/tests/fixtures/expect_error_sample.expected.txt
@@ -17,7 +17,7 @@
 
 <FAILED::>f0 did not raise OSError
 
-<COMPLETEDIN::>0.3
+<COMPLETEDIN::>0.03
 
 <IT::>f1 raises Exception
 

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -23,6 +23,9 @@ def test_against_expected(test_file, expected_file, env):
             expected = re.sub(
                 r"(?<=<COMPLETEDIN::>)\d+(?:\.\d+)?", r"\\d+(?:\\.\\d+)?", r.read()
             )
+            expected = re.sub(
+                r"Error\(([^)]*?)\)", r"Error\\(\1\\)", expected)
+                
             self.assertRegex(result.stdout.decode("utf-8"), expected)
 
     return test

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -24,8 +24,8 @@ def test_against_expected(test_file, expected_file, env):
                 r"(?<=<COMPLETEDIN::>)\d+(?:\.\d+)?", r"\\d+(?:\\.\\d+)?", r.read()
             )
             expected = re.sub(
-                r"Error\(([^)]*?)\)", r"Error\\(\1\\)", expected)
-                
+                r"(Error|Exception)\(([^)]*?)\)", r"\1\\(\2\\)", expected)
+
             self.assertRegex(result.stdout.decode("utf-8"), expected)
 
     return test

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -20,7 +20,7 @@ def test_against_expected(test_file, expected_file, env):
         )
         with open(expected_file, "r", encoding="utf-8") as r:
             # Allow duration to change
-            expected = re.sub( r"[()]", r"\\\1", r.read() )
+            expected = re.sub( r"([()])", r"\\\1", r.read() )
             expected = re.sub(
                 r"(?<=<COMPLETEDIN::>)\d+(?:\.\d+)?", r"\\d+(?:\\.\\d+)?", expected
             )

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -20,7 +20,7 @@ def test_against_expected(test_file, expected_file, env):
         )
         with open(expected_file, "r", encoding="utf-8") as r:
             # Allow duration to change
-            expected = re.sub( r"([()])", r"\\\1", r.read() )
+            expected = re.sub(r"([()])", r"\\\1", r.read())
             expected = re.sub(
                 r"(?<=<COMPLETEDIN::>)\d+(?:\.\d+)?", r"\\d+(?:\\.\\d+)?", expected
             )

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -20,11 +20,10 @@ def test_against_expected(test_file, expected_file, env):
         )
         with open(expected_file, "r", encoding="utf-8") as r:
             # Allow duration to change
+            expected = re.sub( r"[()]", r"\\\1", r.read() )
             expected = re.sub(
-                r"(?<=<COMPLETEDIN::>)\d+(?:\.\d+)?", r"\\d+(?:\\.\\d+)?", r.read()
+                r"(?<=<COMPLETEDIN::>)\d+(?:\.\d+)?", r"\\d+(?:\\.\\d+)?", expected
             )
-            expected = re.sub(
-                r"(Error|Exception)\(([^)]*?)\)", r"\1\\(\2\\)", expected)
 
             self.assertRegex(result.stdout.decode("utf-8"), expected)
 


### PR DESCRIPTION
previously:

when execting a specific error, if any other error is ancountered, the test fails without any useful feedback
suggestion:

added {actual error} should be {expected error} to the message
note:

this time, I updated the related test output fixture. I checked manually that the behavior was exactly the same (hopefuly... x) )