### PR TITLE
Windows compatibility try

### DIFF
--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -19,13 +19,16 @@ def test_against_expected(test_file, expected_file, env):
             stderr=subprocess.STDOUT,
         )
         with open(expected_file, "r", encoding="utf-8") as r:
+            # Escape regular expression
+            pattern = re.sub(r"([()])", r"\\\1", r.read())
+            # Allow CRLF
+            pattern = re.sub("\n", r"\r?\n", pattern)
             # Allow duration to change
-            expected = re.sub(r"([()])", r"\\\1", r.read())
-            expected = re.sub(
-                r"(?<=<COMPLETEDIN::>)\d+(?:\.\d+)?", r"\\d+(?:\\.\\d+)?", expected
+            pattern = re.sub(
+                r"(?<=<COMPLETEDIN::>)\d+(?:\.\d+)?", r"\\d+(?:\\.\\d+)?", pattern
             )
 
-            self.assertRegex(result.stdout.decode("utf-8"), expected)
+            self.assertRegex(result.stdout.decode("utf-8"), pattern)
 
     return test
 

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -16,11 +16,11 @@ def test_against_expected(test_file, expected_file, env):
             ["python", test_file],
             env=env,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
         )
         with open(expected_file, "r", encoding="utf-8") as r:
             # Allow duration to change
-            expected = re.sub(r"([()])", r"\\\1", r.read())
+            expected = re.sub( r"([()])", r"\\\1", r.read() )
             expected = re.sub(
                 r"(?<=<COMPLETEDIN::>)\d+(?:\.\d+)?", r"\\d+(?:\\.\\d+)?", expected
             )
@@ -41,7 +41,7 @@ def test_against_sample(test_file, sample_file, env):
             ["python", test_file],
             env=env,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
         )
         with open(sample_file, "r", encoding="utf-8") as r:
             # Ensure that it contains the same output structure
@@ -62,7 +62,7 @@ def define_tests():
             test_func = test_against_expected(
                 os.path.join(fixtures_dir, f),
                 expected_file,
-                {"PYTHONPATH": package_dir},
+                {"PYTHONPATH": str(package_dir)},
             )
         else:
             # Use `.sample.txt` when testing against outputs with more variables.
@@ -70,7 +70,7 @@ def define_tests():
             test_func = test_against_sample(
                 os.path.join(fixtures_dir, f),
                 os.path.join(fixtures_dir, f.replace(".py", ".sample.txt")),
-                {"PYTHONPATH": package_dir},
+                {"PYTHONPATH": str(package_dir)},
             )
         setattr(TestOutputs, "test_{0}".format(f.replace(".py", "")), test_func)
 

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -20,7 +20,7 @@ def test_against_expected(test_file, expected_file, env):
         )
         with open(expected_file, "r", encoding="utf-8") as r:
             # Allow duration to change
-            expected = re.sub( r"([()])", r"\\\1", r.read() )
+            expected = re.sub(r"([()])", r"\\\1", r.read())
             expected = re.sub(
                 r"(?<=<COMPLETEDIN::>)\d+(?:\.\d+)?", r"\\d+(?:\\.\\d+)?", expected
             )

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -22,7 +22,7 @@ def test_against_expected(test_file, expected_file, env):
             # Escape regular expression
             pattern = re.sub(r"([()])", r"\\\1", r.read())
             # Allow CRLF
-            pattern = re.sub("\n", r"\r?\n", pattern)
+            pattern = re.sub("\n", r"\r?\n", pattern) + r'(?:\r\n)?'
             # Allow duration to change
             pattern = re.sub(
                 r"(?<=<COMPLETEDIN::>)\d+(?:\.\d+)?", r"\\d+(?:\\.\\d+)?", pattern

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -56,13 +56,18 @@ def define_tests():
     fixtures_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "fixtures")
     package_dir = Path(fixtures_dir).parent.parent
     files = (f for f in os.listdir(fixtures_dir) if f.endswith(".py"))
+
+    env = {"PYTHONPATH": str(package_dir)}
+    if "SYSTEMROOT" in os.environ:
+        env["SYSTEMROOT"] = os.environ["SYSTEMROOT"]
+
     for f in files:
         expected_file = os.path.join(fixtures_dir, f.replace(".py", ".expected.txt"))
         if os.path.exists(expected_file):
             test_func = test_against_expected(
                 os.path.join(fixtures_dir, f),
                 expected_file,
-                {"PYTHONPATH": str(package_dir)},
+                env,
             )
         else:
             # Use `.sample.txt` when testing against outputs with more variables.
@@ -70,7 +75,7 @@ def define_tests():
             test_func = test_against_sample(
                 os.path.join(fixtures_dir, f),
                 os.path.join(fixtures_dir, f.replace(".py", ".sample.txt")),
-                {"PYTHONPATH": str(package_dir)},
+                env,
             )
         setattr(TestOutputs, "test_{0}".format(f.replace(".py", "")), test_func)
 


### PR DESCRIPTION
I got a different kind of error, locally, and could get the stdout properly with this.

new error is:

```python
Traceback (most recent call last):
  File ".../GitHub/python-test-framework/tests/test_outputs.py", line 28,
in test
    self.assertRegex(result.stdout.decode("utf-8"), expected)
AssertionError: Regex didn't match: '\n<DESCRIBE::>group 1\n\n<PASSED::>Test Passed\n\n<PASSED::>Test Passed\n\n<COMPLETEDIN::>\\d+(?:\\.\\d+)?\n' not found in 'Fatal Python error: _Py_HashRandomization_Init: failed to get random numbers to initialize Python\nPython runtime state: preinitialized\n\n'
```

Wanting to see how this behaves here...

edit: "reason" for the stderr change: https://stackoverflow.com/questions/10406532/python-subprocess-output-on-windows