### PR TITLE
handling memory error

### DIFF
--- a/tests/fixtures/timeout_passing.expected.txt
+++ b/tests/fixtures/timeout_passing.expected.txt
@@ -3,6 +3,4 @@
 
 <PASSED::>Test Passed
 
-<PASSED::>Test Passed
-
 <COMPLETEDIN::>17.19


### PR DESCRIPTION
* removed the use of `test.expect_no_error` inside the timeout utility:
  - done "manually", allowing to handle data passed to the thread
  - consequence: DOCS need an update because there isn't any extra assertion anymore, now.

* tested on cw with 3.6, 3.8 wihtout imports, 3.8 with imports: work as expected.

* removed a comment in the framework about the timeout (deprecated info)

* added the default message for timeout ssertion (https://github.com/codewars/python-test-framework/issues/4)

Still need to upddate the tests output (and maybe the tests files)