### PR TITLE
README.md: pip installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Codewars Test Framework for Python
 
+### Installation
+
+```bash
+pip install git+https://github.com/codewars/python-test-framework.git#egg=codewars_test
+```
+
 ### Basic Example
 
 ```python


### PR DESCRIPTION
To use codewars_test locally, I need to install it. I had to search the web for the necessary command and URL format, and I thought it would be nice to have the command directly here in the readme.