### PR TITLE
Prevent AssertException from crashing tests

### DIFF
--- a/codewars_test/test_framework.py
+++ b/codewars_test/test_framework.py
@@ -112,6 +112,8 @@ def _timed_block_factory(opening_text):
                 func()
             except AssertionError as e:
                 display('FAILED', str(e))
+            except AssertException:
+                pass # assertions emit '<FAIL::>' before throwing the AssertException
             except Exception:
                 fail('Unexpected exception raised')
                 tb_str = ''.join(format_exception(*exc_info()))


### PR DESCRIPTION
A minor change which gracefully handles `AssertException` thrown by assertions from inside of test cases decorated with `@test.it`.

The fix should allow authors to use `allow_raise = True` in a way which does not result in noisy stacktraces.

It **does not** affect test suites which do not use decorators and which use top-level assertions - test suites of this kind continue working as they are today.

Most probably invalidates https://github.com/codewars/python-test-framework/pull/12 but the PR hasn't been worked on since a very long time anyway.